### PR TITLE
Upgrade to Quarkus 3.0

### DIFF
--- a/app/src/main/java/org/lfenergy/compas/sitipe/rest/exception/WebApplicationExceptionHandler.java
+++ b/app/src/main/java/org/lfenergy/compas/sitipe/rest/exception/WebApplicationExceptionHandler.java
@@ -1,0 +1,22 @@
+package org.lfenergy.compas.sitipe.rest.exception;
+
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.ExceptionMapper;
+import jakarta.ws.rs.ext.Provider;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Provider
+public class WebApplicationExceptionHandler implements ExceptionMapper<WebApplicationException> {
+    @Override
+    public Response toResponse(WebApplicationException e) {
+        final Map<String, String> response = new HashMap<>();
+        response.put("message", e.getMessage());
+        return Response.status(e.getResponse().getStatus())
+                .entity(response)
+                .build();
+    }
+}
+

--- a/app/src/main/java/org/lfenergy/compas/sitipe/rest/monitoring/LivenessHealthCheck.java
+++ b/app/src/main/java/org/lfenergy/compas/sitipe/rest/monitoring/LivenessHealthCheck.java
@@ -8,7 +8,7 @@ import org.eclipse.microprofile.health.HealthCheck;
 import org.eclipse.microprofile.health.HealthCheckResponse;
 import org.eclipse.microprofile.health.Liveness;
 
-import javax.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.ApplicationScoped;
 
 @Liveness
 @ApplicationScoped

--- a/app/src/main/java/org/lfenergy/compas/sitipe/rest/monitoring/ReadinessHealthCheck.java
+++ b/app/src/main/java/org/lfenergy/compas/sitipe/rest/monitoring/ReadinessHealthCheck.java
@@ -8,7 +8,7 @@ import org.eclipse.microprofile.health.HealthCheck;
 import org.eclipse.microprofile.health.HealthCheckResponse;
 import org.eclipse.microprofile.health.Readiness;
 
-import javax.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.ApplicationScoped;
 
 @Readiness
 @ApplicationScoped

--- a/app/src/main/java/org/lfenergy/compas/sitipe/rest/v1/BayTypicalResource.java
+++ b/app/src/main/java/org/lfenergy/compas/sitipe/rest/v1/BayTypicalResource.java
@@ -10,13 +10,13 @@ import io.smallrye.mutiny.Uni;
 import org.lfenergy.compas.sitipe.rest.v1.model.BayTypicalResponse;
 import org.lfenergy.compas.sitipe.service.BayTypicalService;
 
-import javax.enterprise.context.RequestScoped;
-import javax.inject.Inject;
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.Consumes;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
 import java.util.stream.Collectors;
 
 @Authenticated

--- a/app/src/main/java/org/lfenergy/compas/sitipe/rest/v1/model/BayTypicalResponse.java
+++ b/app/src/main/java/org/lfenergy/compas/sitipe/rest/v1/model/BayTypicalResponse.java
@@ -7,10 +7,10 @@ package org.lfenergy.compas.sitipe.rest.v1.model;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.lfenergy.compas.sitipe.dto.BayTypicalDTO;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 import java.util.List;
 
 import static org.lfenergy.compas.sitipe.Constants.SITIPE_SERVICE_V1_NS_URI;

--- a/app/src/main/java/org/lfenergy/compas/sitipe/rest/v2/BTComponentResource.java
+++ b/app/src/main/java/org/lfenergy/compas/sitipe/rest/v2/BTComponentResource.java
@@ -11,10 +11,10 @@ import org.lfenergy.compas.sitipe.dto.ImportedComponentDTO;
 import org.lfenergy.compas.sitipe.service.ImportedComponentService;
 import org.lfenergy.compas.sitipe.dto.ImportedDataDTO;
 
-import javax.enterprise.context.RequestScoped;
-import javax.inject.Inject;
-import javax.ws.rs.*;
-import javax.ws.rs.core.MediaType;
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.MediaType;
 import java.util.List;
 
 @Authenticated

--- a/app/src/main/java/org/lfenergy/compas/sitipe/rest/v2/BayTypicalResource.java
+++ b/app/src/main/java/org/lfenergy/compas/sitipe/rest/v2/BayTypicalResource.java
@@ -12,10 +12,10 @@ import org.lfenergy.compas.sitipe.service.BTComponentService;
 import org.lfenergy.compas.sitipe.dto.BayTypicalDTO;
 import org.lfenergy.compas.sitipe.service.BayTypicalService;
 
-import javax.enterprise.context.RequestScoped;
-import javax.inject.Inject;
-import javax.ws.rs.*;
-import javax.ws.rs.core.MediaType;
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.MediaType;
 import java.util.List;
 
 @Authenticated

--- a/app/src/test/java/org/lfenergy/compas/sitipe/BaseIntegrationTest.java
+++ b/app/src/test/java/org/lfenergy/compas/sitipe/BaseIntegrationTest.java
@@ -7,7 +7,7 @@ package org.lfenergy.compas.sitipe;
 import org.junit.jupiter.api.AfterEach;
 import org.lfenergy.compas.sitipe.helper.DatabaseCleaner;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 public class BaseIntegrationTest {
 

--- a/app/src/test/java/org/lfenergy/compas/sitipe/helper/CompressionUtils.java
+++ b/app/src/test/java/org/lfenergy/compas/sitipe/helper/CompressionUtils.java
@@ -4,7 +4,7 @@
 
 package org.lfenergy.compas.sitipe.helper;
 
-import javax.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.ApplicationScoped;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.zip.DeflaterOutputStream;

--- a/app/src/test/java/org/lfenergy/compas/sitipe/helper/DatabaseCleaner.java
+++ b/app/src/test/java/org/lfenergy/compas/sitipe/helper/DatabaseCleaner.java
@@ -9,9 +9,9 @@ import org.lfenergy.compas.sitipe.data.repository.BayTypicalRepository;
 import org.lfenergy.compas.sitipe.data.repository.ImportedComponentRepository;
 import org.lfenergy.compas.sitipe.data.repository.SystemVersionRepository;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.inject.Inject;
-import javax.transaction.Transactional;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
 
 @ApplicationScoped
 public class DatabaseCleaner {

--- a/app/src/test/java/org/lfenergy/compas/sitipe/helper/SystemVersionHelper.java
+++ b/app/src/test/java/org/lfenergy/compas/sitipe/helper/SystemVersionHelper.java
@@ -14,9 +14,9 @@ import org.lfenergy.compas.sitipe.data.repository.BayTypicalRepository;
 import org.lfenergy.compas.sitipe.data.repository.ImportedComponentRepository;
 import org.lfenergy.compas.sitipe.data.repository.SystemVersionRepository;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.inject.Inject;
-import javax.transaction.Transactional;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
 import java.io.IOException;
 import java.util.*;
 

--- a/app/src/test/java/org/lfenergy/compas/sitipe/rest/v1/BayTypicalResourceTest.java
+++ b/app/src/test/java/org/lfenergy/compas/sitipe/rest/v1/BayTypicalResourceTest.java
@@ -15,7 +15,7 @@ import org.lfenergy.compas.sitipe.data.entity.BayTypical;
 import org.lfenergy.compas.sitipe.data.entity.SystemVersion;
 import org.lfenergy.compas.sitipe.helper.SystemVersionHelper;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 import static io.restassured.RestAssured.given;
 import static java.util.Arrays.asList;

--- a/app/src/test/java/org/lfenergy/compas/sitipe/rest/v2/BTComponentResourceTest.java
+++ b/app/src/test/java/org/lfenergy/compas/sitipe/rest/v2/BTComponentResourceTest.java
@@ -13,7 +13,7 @@ import org.lfenergy.compas.sitipe.BaseIntegrationTest;
 import org.lfenergy.compas.sitipe.data.entity.ImportedComponent;
 import org.lfenergy.compas.sitipe.helper.SystemVersionHelper;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 
 import java.io.IOException;

--- a/app/src/test/java/org/lfenergy/compas/sitipe/rest/v2/BTComponentResourceTest.java
+++ b/app/src/test/java/org/lfenergy/compas/sitipe/rest/v2/BTComponentResourceTest.java
@@ -95,12 +95,13 @@ class BTComponentResourceTest extends BaseIntegrationTest {
         var response = given()
                 .when().get("/imported/{id}", 10)
                 .then()
-                .statusCode(500)
+                .statusCode(404)
                 .extract()
                 .response();
 
+
         JsonPath jsonPath = response.jsonPath();
 
-        assertEquals("CORE-9999", ((LinkedHashMap<String, ?>)((ArrayList)((LinkedHashMap<String, ?>)jsonPath.get()).get("errorMessages")).get(0)).get("code"));
+        assertEquals("Imported BT Component not found", jsonPath.getString("message"));
     }
 }

--- a/app/src/test/java/org/lfenergy/compas/sitipe/rest/v2/BayTypicalResourceTest.java
+++ b/app/src/test/java/org/lfenergy/compas/sitipe/rest/v2/BayTypicalResourceTest.java
@@ -19,9 +19,9 @@ import org.lfenergy.compas.sitipe.data.entity.SystemVersion;
 import org.lfenergy.compas.sitipe.dto.BTComponentDTO;
 import org.lfenergy.compas.sitipe.helper.SystemVersionHelper;
 
-import javax.inject.Inject;
-import javax.ws.rs.*;
-import javax.ws.rs.core.MediaType;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.MediaType;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;

--- a/pom.xml
+++ b/pom.xml
@@ -24,9 +24,8 @@ SPDX-License-Identifier: Apache-2.0
         <sonarqube-plugin.version>3.2.0</sonarqube-plugin.version>
 
         <compas.core.version>0.12.0</compas.core.version>
-        <quarkus.platform.version>2.16.3.Final</quarkus.platform.version>
+        <quarkus.platform.version>3.0.4.Final</quarkus.platform.version>
 
-        <jaxb-impl.version>2.3.8</jaxb-impl.version>
         <microprofile-openapi-api.version>3.1</microprofile-openapi-api.version>
         <log4j2.version>2.20.0</log4j2.version>
         <openpojo.version>0.9.1</openpojo.version>
@@ -57,8 +56,8 @@ SPDX-License-Identifier: Apache-2.0
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-universe-bom</artifactId>
+                <groupId>io.quarkus.platform</groupId>
+                <artifactId>quarkus-bom</artifactId>
                 <version>${quarkus.platform.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
@@ -89,12 +88,6 @@ SPDX-License-Identifier: Apache-2.0
                 <groupId>org.lfenergy.compas.core</groupId>
                 <artifactId>websocket-commons</artifactId>
                 <version>${compas.core.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>com.sun.xml.bind</groupId>
-                <artifactId>jaxb-impl</artifactId>
-                <version>${jaxb-impl.version}</version>
             </dependency>
 
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@ SPDX-License-Identifier: Apache-2.0
         <surefire-plugin.version>3.0.0-M9</surefire-plugin.version>
         <sonarqube-plugin.version>3.2.0</sonarqube-plugin.version>
 
-        <compas.core.version>0.12.0</compas.core.version>
+        <compas.core.version>0.16.0</compas.core.version>
         <quarkus.platform.version>3.0.4.Final</quarkus.platform.version>
 
         <microprofile-openapi-api.version>3.1</microprofile-openapi-api.version>

--- a/repository/src/main/java/org/lfenergy/compas/sitipe/data/entity/BTComponent.java
+++ b/repository/src/main/java/org/lfenergy/compas/sitipe/data/entity/BTComponent.java
@@ -4,10 +4,10 @@
 
 package org.lfenergy.compas.sitipe.data.entity;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.Id;
-import javax.persistence.Table;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 
 @Entity
 @Table(name = "BTComponents_")

--- a/repository/src/main/java/org/lfenergy/compas/sitipe/data/entity/BayTypical.java
+++ b/repository/src/main/java/org/lfenergy/compas/sitipe/data/entity/BayTypical.java
@@ -4,10 +4,10 @@
 
 package org.lfenergy.compas.sitipe.data.entity;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.Id;
-import javax.persistence.Table;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 
 @Entity
 @Table(name = "BayTypicals_LIST_")

--- a/repository/src/main/java/org/lfenergy/compas/sitipe/data/entity/ImportedComponent.java
+++ b/repository/src/main/java/org/lfenergy/compas/sitipe/data/entity/ImportedComponent.java
@@ -4,7 +4,7 @@
 
 package org.lfenergy.compas.sitipe.data.entity;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 
 @Entity
 @Table(name = "Imported_")

--- a/repository/src/main/java/org/lfenergy/compas/sitipe/data/entity/SystemVersion.java
+++ b/repository/src/main/java/org/lfenergy/compas/sitipe/data/entity/SystemVersion.java
@@ -4,10 +4,10 @@
 
 package org.lfenergy.compas.sitipe.data.entity;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.Id;
-import javax.persistence.Table;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 
 @Entity()
 @Table(name = "SYSTEM_VERSION_LIST_")

--- a/repository/src/main/java/org/lfenergy/compas/sitipe/data/repository/BTComponentRepository.java
+++ b/repository/src/main/java/org/lfenergy/compas/sitipe/data/repository/BTComponentRepository.java
@@ -7,7 +7,7 @@ package org.lfenergy.compas.sitipe.data.repository;
 import io.quarkus.hibernate.orm.panache.PanacheRepository;
 import org.lfenergy.compas.sitipe.data.entity.BTComponent;
 
-import javax.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.ApplicationScoped;
 import java.util.List;
 
 @ApplicationScoped

--- a/repository/src/main/java/org/lfenergy/compas/sitipe/data/repository/BayTypicalRepository.java
+++ b/repository/src/main/java/org/lfenergy/compas/sitipe/data/repository/BayTypicalRepository.java
@@ -7,7 +7,7 @@ package org.lfenergy.compas.sitipe.data.repository;
 import io.quarkus.hibernate.orm.panache.PanacheRepository;
 import org.lfenergy.compas.sitipe.data.entity.BayTypical;
 
-import javax.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.ApplicationScoped;
 import java.util.List;
 
 @ApplicationScoped

--- a/repository/src/main/java/org/lfenergy/compas/sitipe/data/repository/ImportedComponentRepository.java
+++ b/repository/src/main/java/org/lfenergy/compas/sitipe/data/repository/ImportedComponentRepository.java
@@ -7,8 +7,8 @@ package org.lfenergy.compas.sitipe.data.repository;
 import io.quarkus.hibernate.orm.panache.PanacheRepositoryBase;
 import org.lfenergy.compas.sitipe.data.entity.ImportedComponent;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.persistence.LockModeType;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.persistence.LockModeType;
 import java.util.List;
 
 @ApplicationScoped

--- a/repository/src/main/java/org/lfenergy/compas/sitipe/data/repository/SystemVersionRepository.java
+++ b/repository/src/main/java/org/lfenergy/compas/sitipe/data/repository/SystemVersionRepository.java
@@ -7,7 +7,7 @@ package org.lfenergy.compas.sitipe.data.repository;
 import io.quarkus.hibernate.orm.panache.PanacheRepository;
 import org.lfenergy.compas.sitipe.data.entity.SystemVersion;
 
-import javax.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.ApplicationScoped;
 import java.util.List;
 
 @ApplicationScoped

--- a/repository/src/test/java/org/lfenergy/compas/sitipe/data/repository/ImportedComponentRepositoryTest.java
+++ b/repository/src/test/java/org/lfenergy/compas/sitipe/data/repository/ImportedComponentRepositoryTest.java
@@ -12,7 +12,7 @@ import org.lfenergy.compas.sitipe.data.entity.ImportedComponent;
 import org.mockito.ArgumentCaptor;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import javax.persistence.LockModeType;
+import jakarta.persistence.LockModeType;
 import java.util.List;
 import java.util.UUID;
 

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -50,9 +50,9 @@ SPDX-License-Identifier: Apache-2.0
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>javax.ws.rs-api</artifactId>
-            <version>2.1.1</version>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
+            <version>3.1.0</version>
             <scope>compile</scope>
         </dependency>
 

--- a/service/src/main/java/org/lfenergy/compas/sitipe/service/BTComponentService.java
+++ b/service/src/main/java/org/lfenergy/compas/sitipe/service/BTComponentService.java
@@ -7,8 +7,8 @@ package org.lfenergy.compas.sitipe.service;
 import org.lfenergy.compas.sitipe.data.repository.BTComponentRepository;
 import org.lfenergy.compas.sitipe.dto.BTComponentDTO;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.inject.Inject;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
 import java.util.List;
 
 @ApplicationScoped

--- a/service/src/main/java/org/lfenergy/compas/sitipe/service/BTComponentService.java
+++ b/service/src/main/java/org/lfenergy/compas/sitipe/service/BTComponentService.java
@@ -4,6 +4,7 @@
 
 package org.lfenergy.compas.sitipe.service;
 
+import jakarta.transaction.Transactional;
 import org.lfenergy.compas.sitipe.data.repository.BTComponentRepository;
 import org.lfenergy.compas.sitipe.dto.BTComponentDTO;
 
@@ -23,6 +24,7 @@ public class BTComponentService {
         this.btComponentRepository = btComponentRepository;
     }
 
+    @Transactional
     public List<BTComponentDTO> getBTComponentsByBayTypicalAccessId(final String accessId) {
         return btComponentRepository.findBayTypicalComponentsByTypicalAccessId(accessId)
             .stream()

--- a/service/src/main/java/org/lfenergy/compas/sitipe/service/BayTypicalService.java
+++ b/service/src/main/java/org/lfenergy/compas/sitipe/service/BayTypicalService.java
@@ -4,6 +4,7 @@
 
 package org.lfenergy.compas.sitipe.service;
 
+import jakarta.transaction.Transactional;
 import org.lfenergy.compas.sitipe.SitipeProperties;
 import org.lfenergy.compas.sitipe.data.repository.BayTypicalRepository;
 import org.lfenergy.compas.sitipe.data.repository.SystemVersionRepository;
@@ -33,6 +34,7 @@ public class BayTypicalService {
         this.sitipeProperties = sitipeProperties;
     }
 
+    @Transactional
     public List<BayTypicalDTO> getAssignedBayTypicals() {
         return this.systemVersionRepository.findByVersion(sitipeProperties.version())
             .stream()

--- a/service/src/main/java/org/lfenergy/compas/sitipe/service/BayTypicalService.java
+++ b/service/src/main/java/org/lfenergy/compas/sitipe/service/BayTypicalService.java
@@ -9,8 +9,8 @@ import org.lfenergy.compas.sitipe.data.repository.BayTypicalRepository;
 import org.lfenergy.compas.sitipe.data.repository.SystemVersionRepository;
 import org.lfenergy.compas.sitipe.dto.BayTypicalDTO;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.inject.Inject;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;

--- a/service/src/main/java/org/lfenergy/compas/sitipe/service/ImportedComponentService.java
+++ b/service/src/main/java/org/lfenergy/compas/sitipe/service/ImportedComponentService.java
@@ -35,6 +35,7 @@ public class ImportedComponentService {
         this.importedComponentRepository = importedComponentRepository;
     }
 
+    @Transactional
     public List<ImportedComponentDTO> getByAccessId(final String accessId) {
         return importedComponentRepository.getByAccessId(accessId)
             .stream()
@@ -42,6 +43,7 @@ public class ImportedComponentService {
             .toList();
     }
 
+    @Transactional
     public ImportedDataDTO getImportedComponentData(final Integer id) {
         final ImportedComponent importedComponent = this.getEntity(id);
 

--- a/service/src/main/java/org/lfenergy/compas/sitipe/service/ImportedComponentService.java
+++ b/service/src/main/java/org/lfenergy/compas/sitipe/service/ImportedComponentService.java
@@ -9,11 +9,11 @@ import org.lfenergy.compas.sitipe.data.repository.ImportedComponentRepository;
 import org.lfenergy.compas.sitipe.dto.ImportedComponentDTO;
 import org.lfenergy.compas.sitipe.dto.ImportedDataDTO;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.inject.Inject;
-import javax.transaction.Transactional;
-import javax.ws.rs.InternalServerErrorException;
-import javax.ws.rs.NotFoundException;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import jakarta.ws.rs.InternalServerErrorException;
+import jakarta.ws.rs.NotFoundException;
 import java.io.*;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
@@ -74,7 +74,7 @@ public class ImportedComponentService {
     }
 
     @Transactional
-    private ImportedComponent getEntity(final Integer id) {
+    public ImportedComponent getEntity(final Integer id) {
         return importedComponentRepository.getById(id);
     }
 }


### PR DESCRIPTION
- update Quarkus bom from `io.quarkus:quarkus-universe-bom` to `io.quarkus.platform:quarkus-bom` as it was deprecated since Quarkus 2.1 https://github.com/quarkusio/quarkus/wiki/Migration-Guide-2.1#quarkus-universe-bom-is-deprecated (and it is required to use the Quarkus migration tool)
- launched quarkus `quarkus update --stream=3.0` as mentioned in https://github.com/quarkusio/quarkus/wiki/Migration-Guide-3.0#automatic-update-tool which dealt with a fair part of the migration. Then it remained few little tasks.
- removed no more necessary com.sun.xml.bind:jaxb-impl
- Change method visibility from private to public org.lfenergy.compas.sitipe.service.ImportedComponentService.getEntity(Integer) to avoid test failure:
```
BayTypicalResourceTest.itShouldReturnEmptyListWhenNoBayTypicalsAreFound
» Runtime java.lang.RuntimeException: io.quarkus.builder.BuildException:
Build failure: Build failed due to errors
	[error]: Build step io.quarkus.arc.deployment.ArcProcessor#validate
threw an exception: jakarta.enterprise.inject.spi.DeploymentException:
@Transactional will have no effect on method
org.lfenergy.compas.sitipe.service.ImportedComponentService.getEntity()
because the method is private. Either remove the annotation from the
method, or turn this exception into a simple warning by setting
configuration property 'quarkus.arc.fail-on-intercepted-private-method'
to 'false'.
```

fixes #11

